### PR TITLE
chore: update bundled croc to v10.7.0

### DIFF
--- a/.github/workflows/build-gui.yml
+++ b/.github/workflows/build-gui.yml
@@ -16,7 +16,7 @@ permissions:
   contents: read
 
 env:
-  CROC_VERSION: latest
+  CROC_VERSION: v10.7.0
 
 jobs:
   build:
@@ -91,7 +91,11 @@ jobs:
           set -euo pipefail
           mkdir -p src-tauri/bin
           ASSET_SUFFIX="${{ matrix.croc_asset }}"
-          DOWNLOAD_URL=$(gh api repos/schollz/croc/releases/latest | node -e '
+          RELEASE_ENDPOINT="repos/schollz/croc/releases/latest"
+          if [ "${CROC_VERSION}" != "latest" ]; then
+            RELEASE_ENDPOINT="repos/schollz/croc/releases/tags/${CROC_VERSION}"
+          fi
+          DOWNLOAD_URL=$(gh api "$RELEASE_ENDPOINT" | node -e '
             const fs = require("fs");
             const data = JSON.parse(fs.readFileSync(0, "utf8"));
             const suffix = process.env.ASSET_SUFFIX;

--- a/.github/workflows/release-gui.yml
+++ b/.github/workflows/release-gui.yml
@@ -16,6 +16,7 @@ permissions:
 
 env:
   RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+  CROC_VERSION: v10.7.0
 
 jobs:
   release:
@@ -92,7 +93,11 @@ jobs:
           set -euo pipefail
           mkdir -p src-tauri/bin
           ASSET_SUFFIX="${{ matrix.croc_asset }}"
-          DOWNLOAD_URL=$(gh api repos/schollz/croc/releases/latest | node -e '
+          RELEASE_ENDPOINT="repos/schollz/croc/releases/latest"
+          if [ "${CROC_VERSION}" != "latest" ]; then
+            RELEASE_ENDPOINT="repos/schollz/croc/releases/tags/${CROC_VERSION}"
+          fi
+          DOWNLOAD_URL=$(gh api "$RELEASE_ENDPOINT" | node -e '
             const fs = require("fs");
             const data = JSON.parse(fs.readFileSync(0, "utf8"));
             const suffix = process.env.ASSET_SUFFIX;

--- a/gui/scripts/bundle-croc.mjs
+++ b/gui/scripts/bundle-croc.mjs
@@ -5,7 +5,7 @@
  *
  * Usage:
  *   node scripts/bundle-croc.mjs              # from PATH or CROC_BIN
- *   node scripts/bundle-croc.mjs --download   # fetch latest GitHub release
+ *   node scripts/bundle-croc.mjs --download   # fetch GitHub release (CROC_VERSION or latest)
  *   CROC_BIN=/path/to/croc node scripts/bundle-croc.mjs
  */
 import { execFileSync, spawnSync } from "node:child_process";
@@ -31,6 +31,7 @@ const destName = isWin ? "croc.exe" : "croc";
 const dest = join(binDir, destName);
 
 const wantDownload = process.argv.includes("--download");
+const requestedVersion = (process.env.CROC_VERSION || "latest").trim() || "latest";
 
 function which(cmd) {
   const probe = isWin ? "where" : "command";
@@ -94,8 +95,11 @@ function assetForHost() {
 
 function downloadLatest() {
   const suffix = assetForHost();
-  const api = "https://api.github.com/repos/schollz/croc/releases/latest";
-  console.log("Fetching latest croc release metadata…");
+  const api =
+    requestedVersion === "latest"
+      ? "https://api.github.com/repos/schollz/croc/releases/latest"
+      : `https://api.github.com/repos/schollz/croc/releases/tags/${encodeURIComponent(requestedVersion)}`;
+  console.log(`Fetching croc release metadata (${requestedVersion})…`);
   const metaRaw = execFileSync("curl", ["-fsSL", api], { encoding: "utf8" });
   const meta = JSON.parse(metaRaw);
   const asset = (meta.assets || []).find((a) =>

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -314,7 +314,7 @@ function App() {
     if (!isTauri) {
       setBinPath("bundled");
       setBinError(null);
-      setCrocVersion("10.6.0");
+      setCrocVersion("10.7.0");
     }
 
     if (cap === "receive") setMode("receive");


### PR DESCRIPTION
## Summary
- Pins CI/release croc downloads to upstream v10.7.0
- Allows local bundle script to fetch a specific croc release via CROC_VERSION
- Updates dev screenshot fallback version text to 10.7.0

## Test Plan
- CROC_VERSION=v10.7.0 npm run bundle:croc:download
- ./src-tauri/bin/croc --version
- npm run build
- npm run test
- npm run test:rust
- npm run tauri:build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated GUI builds and releases to use Croc version 10.7.0 consistently.
  * Ensured downloads retrieve the configured Croc version rather than unintentionally using the latest release.
* **Documentation**
  * Clarified command-line usage for selecting a specific Croc release.
* **UI**
  * Updated the displayed bundled Croc version to 10.7.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->