### PR TITLE
Polish transfer UI with hero CTAs, status pill, motion, and compact logs

### DIFF
--- a/gui/src/App.css
+++ b/gui/src/App.css
@@ -97,11 +97,20 @@ body {
 .header-btn-row {
   display: flex;
   align-items: center;
-  gap: 0.25rem;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+/* Icon-only controls (theme toggle) get a generous, square hit target. */
+.icon-btn {
+  min-width: 2.5rem;
+  height: 2.5rem;
+  padding: 0;
+  font-size: 1rem;
 }
 
 .about-btn {
-  font-size: 0.82rem;
+  font-size: 0.85rem;
 }
 
 .main {
@@ -181,15 +190,31 @@ code {
 
 .panel-cta {
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.55rem;
+  margin-top: 0.75rem;
+  padding-top: 0.85rem;
+  border-top: 1px solid var(--line);
+}
+
+/* Primary call-to-action: a full-width hero button that clearly
+   dominates the panel and reads as the obvious next step. */
+.cta-primary {
+  width: 100%;
   justify-content: center;
-  gap: 0.6rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.panel-cta .row {
+  justify-content: center;
 }
 
 .panel-cta-hint {
   font-size: 0.8rem;
   color: var(--muted);
+  text-align: center;
 }
 
 .sent-file-list {
@@ -363,18 +388,38 @@ code {
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  border: 0;
+  border: 1px solid transparent;
+  border-radius: var(--radius-box);
   background: transparent;
-  padding: 0.15rem 0;
+  padding: 0.5rem 0.6rem;
   cursor: pointer;
   font: inherit;
   font-size: 0.95rem;
   font-weight: 550;
   color: var(--ink);
+  transition: background 140ms ease, border-color 140ms ease;
+}
+
+.options-toggle:hover:not(:disabled) {
+  background: var(--bg-accent);
+  border-color: var(--line);
+}
+
+.options-toggle:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 55%, transparent);
+  outline-offset: 1px;
 }
 
 .chevron {
   color: var(--muted);
+  display: inline-block;
+  transition: transform 180ms ease;
+}
+
+/* Collapsible toggles always render ▸; rotate it open via aria-expanded. */
+[aria-expanded="true"] > .chevron,
+[aria-expanded="true"] .chevron {
+  transform: rotate(90deg);
 }
 
 .options,
@@ -433,8 +478,61 @@ code {
   color: var(--muted);
 }
 
-.status-idle {
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.45;
+    transform: scale(0.8);
+  }
+}
+
+/* Compact status pill shown in the footer meta row. */
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.8rem;
+  font-weight: 500;
   color: var(--muted);
+  padding: 0.18rem 0.6rem;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: var(--panel);
+}
+
+.status-dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: currentColor;
+  flex-shrink: 0;
+}
+
+.status-pill.status-running {
+  color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 40%, var(--line));
+  background: var(--accent-soft);
+}
+
+.status-pill.status-running .status-dot {
+  animation: pulse 1.2s ease-in-out infinite;
+}
+
+.status-pill.status-completed {
+  color: var(--success-ink);
+  border-color: color-mix(in srgb, var(--success-ink) 40%, var(--line));
+  background: var(--success-bg);
+}
+
+.status-pill.status-failed,
+.status-pill.status-cancelled {
+  color: var(--danger);
+  border-color: color-mix(in srgb, var(--danger) 40%, var(--line));
+  background: var(--error-bg);
 }
 
 .status-running {
@@ -450,22 +548,18 @@ code {
   color: var(--danger);
 }
 
-.workflow-status {
-  margin: 0;
-  text-align: center;
-  font-size: 0.9rem;
-}
-
-/* Log */
+/* Log: compact terminal-style output. Consecutive duplicate lines are
+   collapsed with a ×N counter (see appendLogLine) to stay readable. */
 .log pre {
   margin: 0;
-  padding: 0.6rem;
-  max-height: 14rem;
+  padding: 0.45rem 0.55rem;
+  max-height: 8.5rem;
   overflow: auto;
+  scroll-behavior: smooth;
   background: color-mix(in srgb, var(--bg-accent) 70%, transparent);
   font-family: "IBM Plex Mono", ui-monospace, monospace;
-  font-size: 0.8rem;
-  line-height: 1.5;
+  font-size: 0.72rem;
+  line-height: 1.45;
   white-space: pre-wrap;
   word-break: break-word;
 }
@@ -480,6 +574,16 @@ code {
   cursor: pointer;
   font: inherit;
   flex: 1;
+}
+
+.log-toggle:hover:not(:disabled) {
+  color: var(--accent);
+}
+
+.log-toggle:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 55%, transparent);
+  outline-offset: 2px;
+  border-radius: var(--radius-box);
 }
 
 .log-count {
@@ -595,20 +699,26 @@ code {
   color: var(--muted);
 }
 
-/* Options & credits */
+/* Footer: a slim single-line status bar — transfer status on the left,
+   credits/links on the right. Wraps gracefully on very narrow windows. */
 .footer {
   margin-top: auto;
-  font-size: 0.78rem;
+  font-size: 0.75rem;
   display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem 1rem;
+  flex-wrap: wrap;
+  padding-top: 0.6rem;
+  border-top: 1px solid var(--line);
 }
 
-.footer-meta {
+.footer-status {
   display: flex;
-  justify-content: space-between;
-  gap: 0.75rem;
-  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.6rem;
+  white-space: nowrap;
 }
 
 .muted {
@@ -623,10 +733,8 @@ code {
   margin: 0;
   color: var(--muted);
   line-height: 1.4;
-}
-
-.credit-gui {
-  font-size: 0.75rem;
+  text-align: right;
+  white-space: nowrap;
 }
 
 button.linkish {
@@ -669,6 +777,100 @@ button.linkish:hover:not(:disabled) {
 .about-blurb {
   margin: 0 0 0.75rem;
   font-size: 0.88rem;
+}
+
+/* ---- Motion ---------------------------------------------------------- */
+/* Panels rise in whenever they mount (tab switches, phase changes), with a
+   light stagger so the workflow reads as one smooth cascade. */
+@keyframes rise {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes pop-in {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.header,
+.footer {
+  animation: rise 280ms cubic-bezier(0.22, 0.9, 0.32, 1) both;
+}
+
+.main > * {
+  animation: rise 260ms cubic-bezier(0.22, 0.9, 0.32, 1) both;
+}
+
+.main > *:nth-child(2) {
+  animation-delay: 40ms;
+}
+
+.main > *:nth-child(3) {
+  animation-delay: 80ms;
+}
+
+.main > *:nth-child(4) {
+  animation-delay: 120ms;
+}
+
+.main > *:nth-child(n + 5) {
+  animation-delay: 150ms;
+}
+
+/* Buttons lift slightly on hover and press down on click. */
+.btn {
+  transition:
+    transform 150ms ease,
+    background-color 150ms ease,
+    border-color 150ms ease,
+    color 150ms ease,
+    box-shadow 150ms ease;
+}
+
+.btn:not(:disabled):hover {
+  transform: translateY(-1px);
+}
+
+.btn:not(:disabled):active {
+  transform: translateY(0) scale(0.98);
+}
+
+/* Smooth progress bar fill instead of jumpy steps. */
+.progress::-webkit-progress-value {
+  transition: width 300ms ease;
+}
+
+.progress::-moz-progress-bar {
+  transition: width 300ms ease;
+}
+
+/* Modal + success badge entrances. */
+.modal-box {
+  animation: pop-in 180ms cubic-bezier(0.22, 0.9, 0.32, 1) both;
+}
+
+.success-count {
+  animation: pop-in 240ms cubic-bezier(0.22, 0.9, 0.32, 1) both;
+}
+
+/* Status pill cross-fades between phase colors. */
+.status-pill {
+  transition:
+    color 180ms ease,
+    background-color 180ms ease,
+    border-color 180ms ease;
 }
 
 @media (max-width: 640px) {

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -8,6 +8,7 @@ import { open } from "@tauri-apps/plugin-dialog";
 import { openUrl, revealItemInDir } from "@tauri-apps/plugin-opener";
 import QRCode from "qrcode";
 import { applyProxyFieldNormalization } from "./proxyPaste";
+import { appendLogLine } from "./logUtils";
 import { SharePhraseBlock } from "./components/SharePhraseBlock";
 import { TransferFileList } from "./components/TransferFileList";
 import { TransferProgressBlock } from "./components/TransferProgressBlock";
@@ -615,7 +616,7 @@ function App() {
     (async () => {
       unlistenLine = await listen<LineEvent>("transfer-line", (event) => {
         const { line, code } = event.payload;
-        setLog((prev) => [...prev.slice(-199), line]);
+        setLog((prev) => appendLogLine(prev, line));
         if (code) {
           setPhrase(code);
         }
@@ -1250,7 +1251,7 @@ function App() {
           <div className="header-btn-row">
           <button
             type="button"
-            className="btn btn-ghost btn-sm about-btn"
+            className="btn btn-ghost icon-btn"
             onClick={() => setTheme((t) => (t === "dark" ? "light" : "dark"))}
             aria-label={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
             title={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
@@ -1396,7 +1397,7 @@ function App() {
                 <div className="panel-cta panel-cta-running">
                   <button
                     type="button"
-                    className="btn btn-error"
+                    className="btn btn-error cta-primary"
                     onClick={onCancel}
                     title="Cancel transfer (Esc)"
                   >
@@ -1429,27 +1430,29 @@ function App() {
                 <div className="panel-cta panel-cta-sent">
                   <button
                     type="button"
-                    className="btn btn-primary"
+                    className="btn btn-primary btn-lg cta-primary"
                     onClick={() => void onStartAnotherTransfer()}
                   >
                     Start another transfer
                   </button>
-                  <button
-                    type="button"
-                    className="btn btn-outline btn-primary"
-                    onClick={() => void onSendSameFilesAgain()}
-                    disabled={
-                      (transferPaths.length > 0 ? transferPaths : paths)
-                        .length === 0
-                    }
-                  >
-                    Send same files again
-                  </button>
+                  <div className="row">
+                    <button
+                      type="button"
+                      className="btn btn-outline btn-primary"
+                      onClick={() => void onSendSameFilesAgain()}
+                      disabled={
+                        (transferPaths.length > 0 ? transferPaths : paths)
+                          .length === 0
+                      }
+                    >
+                      Send same files again
+                    </button>
+                  </div>
+                  <p className="sent-hint panel-cta-hint">
+                    Start another for a clean slate, or resend the same files
+                    with a fresh code.
+                  </p>
                 </div>
-                <p className="sent-hint">
-                  Start another for a clean slate, or send the same files with a
-                  fresh code.
-                </p>
               </div>
             ) : (
               <>
@@ -1489,14 +1492,14 @@ function App() {
                       <div className="row">
                         <button
                           type="button"
-                          className="btn btn-outline btn-primary btn-sm"
+                          className="btn btn-outline btn-primary"
                           onClick={pickSendPaths}
                         >
                           Add files
                         </button>
                         <button
                           type="button"
-                          className="btn btn-outline btn-primary btn-sm"
+                          className="btn btn-outline btn-primary"
                           onClick={pickSendFolder}
                         >
                           Add folder
@@ -1508,21 +1511,21 @@ function App() {
                       <div className="row">
                         <button
                           type="button"
-                          className="btn btn-outline btn-primary btn-sm"
+                          className="btn btn-outline btn-primary"
                           onClick={pickSendPaths}
                         >
                           Add files
                         </button>
                         <button
                           type="button"
-                          className="btn btn-outline btn-primary btn-sm"
+                          className="btn btn-outline btn-primary"
                           onClick={pickSendFolder}
                         >
                           Add folder
                         </button>
                         <button
                           type="button"
-                          className="btn btn-ghost btn-sm"
+                          className="btn btn-ghost"
                           onClick={() => setPaths([])}
                         >
                           Clear
@@ -1539,7 +1542,7 @@ function App() {
                             </span>
                             <button
                               type="button"
-                              className="btn btn-ghost btn-xs path-remove"
+                              className="btn btn-ghost btn-sm path-remove"
                               onClick={() => removePath(p)}
                               aria-label={`Remove ${basename(p)}`}
                             >
@@ -1560,16 +1563,18 @@ function App() {
                 >
                   <button
                     type="button"
-                    className="btn btn-primary btn-lg"
+                    className="btn btn-primary btn-lg cta-primary"
                     onClick={onStart}
                     disabled={!canStart}
                     title={startButtonTitle}
                   >
-                    Start transfer
+                    {paths.length > 0
+                      ? `Send ${paths.length} file${paths.length === 1 ? "" : "s"}`
+                      : "Start transfer"}
                   </button>
                   <span className="panel-cta-hint">
                     {paths.length > 0
-                      ? `${paths.length} file${paths.length === 1 ? "" : "s"} ready`
+                      ? "Ready — a short code will be generated"
                       : "Add files to continue"}
                   </span>
                 </div>
@@ -1623,7 +1628,7 @@ function App() {
                 <div className="panel-cta panel-cta-running">
                   <button
                     type="button"
-                    className="btn btn-error"
+                    className="btn btn-error cta-primary"
                     onClick={onCancel}
                     title="Cancel transfer (Esc)"
                   >
@@ -1744,7 +1749,7 @@ function App() {
                 >
                   <button
                     type="button"
-                    className="btn btn-primary btn-lg"
+                    className="btn btn-primary btn-lg cta-primary"
                     onClick={onStart}
                     disabled={!canStart}
                     title={startButtonTitle}
@@ -1774,7 +1779,7 @@ function App() {
           >
             <span>Options</span>
             <span className="chevron" aria-hidden>
-              {optionsOpen ? "▾" : "▸"}
+              ▸
             </span>
           </button>
           {optionsOpen && (
@@ -2004,7 +2009,7 @@ function App() {
               >
                 <span>Advanced network</span>
                 <span className="chevron" aria-hidden>
-                  {advancedOpen ? "▾" : "▸"}
+                  ▸
                 </span>
               </button>
               {advancedOpen && (
@@ -2107,12 +2112,6 @@ function App() {
           </section>
         )}
 
-        {!running && phase !== "completed" && (
-          <p className="workflow-status" aria-live="polite">
-            <span className={`status status-${phase}`}>{phaseLabel[phase]}</span>
-          </p>
-        )}
-
         {!running && phase !== "completed" && history.length > 0 && (
           <section className="panel history-panel">
             <button
@@ -2125,10 +2124,11 @@ function App() {
                 Recent transfers <span className="count">({history.length})</span>
               </span>
               <span className="chevron" aria-hidden>
-                {historyOpen ? "▾" : "▸"}
+                ▸
               </span>
             </button>
             {historyOpen && (
+              <>
               <ul className="history-list">
                 {history.map((h) => (
                   <li key={h.id} className="history-item">
@@ -2157,16 +2157,17 @@ function App() {
                   </li>
                 ))}
               </ul>
+              <div className="history-actions">
+                <button
+                  type="button"
+                  className="btn btn-ghost btn-sm"
+                  onClick={clearHistory}
+                >
+                  Clear history
+                </button>
+              </div>
+              </>
             )}
-            <div className="history-actions">
-              <button
-                type="button"
-                className="btn btn-ghost btn-xs"
-                onClick={clearHistory}
-              >
-                Clear history
-              </button>
-            </div>
           </section>
         )}
 
@@ -2188,7 +2189,7 @@ function App() {
                 </span>
               )}
               <span className="chevron" aria-hidden>
-                {logExpanded ? "▾" : "▸"}
+                ▸
               </span>
             </button>
             {logExpanded && log.length > 0 && (
@@ -2214,16 +2215,21 @@ function App() {
       </main>
 
       <footer className="footer">
-        <div className="footer-meta">
-          {binPath ? (
-            <span className="muted" title={binPath}>
-              Using bundled croc
-            </span>
-          ) : (
-            <span className="muted">croc binary not ready</span>
-          )}
+        <div className="footer-status">
+          <span
+            className={`status-pill status-${phase}`}
+            aria-live="polite"
+            title={
+              binPath
+                ? `Status: ${phaseLabel[phase]} · bundled croc ready`
+                : `Status: ${phaseLabel[phase]} · croc binary not ready`
+            }
+          >
+            <span className="status-dot" aria-hidden />
+            {phaseLabel[phase]}
+          </span>
           <span className="muted shortcuts">
-            {running ? "Esc cancel" : "⌘/Ctrl+Enter start"}
+            {running ? "Esc to cancel" : "⌘/Ctrl+Enter to start"}
           </span>
         </div>
         <p className="credit">
@@ -2234,24 +2240,6 @@ function App() {
             onClick={() => void openUrl("https://github.com/schollz/croc")}
           >
             schollz/croc
-          </button>{" "}
-          ·{" "}
-          <button
-            type="button"
-            className="linkish"
-            onClick={() => void openUrl("https://github.com/sponsors/schollz")}
-          >
-            Sponsor schollz
-          </button>
-        </p>
-        <p className="credit credit-gui">
-          GUI by{" "}
-          <button
-            type="button"
-            className="linkish"
-            onClick={() => void openUrl("https://github.com/interfluve-wav")}
-          >
-            interfluve-wav
           </button>
           {" · "}
           <button
@@ -2261,7 +2249,15 @@ function App() {
               void openUrl("https://github.com/interfluve-wav/croc-gui")
             }
           >
-            croc-gui
+            GUI repo
+          </button>
+          {" · "}
+          <button
+            type="button"
+            className="linkish"
+            onClick={() => setAboutOpen(true)}
+          >
+            Credits
           </button>
         </p>
       </footer>

--- a/gui/src/logUtils.test.ts
+++ b/gui/src/logUtils.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { appendLogLine, LOG_MAX_LINES } from "./logUtils";
+
+describe("appendLogLine", () => {
+  it("appends a new line to an empty log", () => {
+    expect(appendLogLine([], "hello")).toEqual(["hello"]);
+  });
+
+  it("appends distinct lines in order", () => {
+    expect(appendLogLine(["a"], "b")).toEqual(["a", "b"]);
+  });
+
+  it("collapses a consecutive duplicate into a ×2 suffix", () => {
+    expect(appendLogLine(["a", "b"], "b")).toEqual(["a", "b ×2"]);
+  });
+
+  it("increments the counter on further duplicates", () => {
+    const log = appendLogLine(["a", "b ×2"], "b");
+    expect(log).toEqual(["a", "b ×3"]);
+    expect(appendLogLine(log, "b")).toEqual(["a", "b ×4"]);
+  });
+
+  it("does not collapse non-consecutive duplicates", () => {
+    expect(appendLogLine(["a", "b"], "a")).toEqual(["a", "b", "a"]);
+  });
+
+  it("starts a fresh line after a different line intervenes", () => {
+    const log = appendLogLine(["a ×2", "b"], "a");
+    expect(log).toEqual(["a ×2", "b", "a"]);
+  });
+
+  it("caps the log at the maximum, dropping oldest lines", () => {
+    const full = Array.from({ length: LOG_MAX_LINES }, (_, i) => `line-${i}`);
+    const next = appendLogLine(full, "new");
+    expect(next).toHaveLength(LOG_MAX_LINES);
+    expect(next[0]).toBe("line-1");
+    expect(next[next.length - 1]).toBe("new");
+  });
+
+  it("respects a custom max", () => {
+    const next = appendLogLine(["a", "b", "c"], "d", 3);
+    expect(next).toEqual(["b", "c", "d"]);
+  });
+});

--- a/gui/src/logUtils.ts
+++ b/gui/src/logUtils.ts
@@ -1,0 +1,29 @@
+/** Maximum number of log lines kept in memory / rendered. */
+export const LOG_MAX_LINES = 200;
+
+/** Matches a trailing repeat counter added by `appendLogLine` ("line ×3"). */
+const REPEAT_SUFFIX = /^(.*) ×(\d+)$/s;
+
+/**
+ * Appends a line to the transfer log, collapsing consecutive duplicates into
+ * a single line with a `×N` suffix. croc emits many repeated lines (progress
+ * redraws, relay reconnects), so this keeps the log compact and readable.
+ *
+ * The returned array is capped at `max` lines, dropping the oldest first.
+ */
+export function appendLogLine(
+  prev: readonly string[],
+  line: string,
+  max: number = LOG_MAX_LINES,
+): string[] {
+  const last = prev[prev.length - 1];
+  if (last !== undefined) {
+    const match = REPEAT_SUFFIX.exec(last);
+    const base = match ? match[1] : last;
+    if (base === line) {
+      const count = match ? Number.parseInt(match[2], 10) + 1 : 2;
+      return [...prev.slice(0, -1), `${line} ×${count}`];
+    }
+  }
+  return [...prev.slice(-(max - 1)), line];
+}


### PR DESCRIPTION
## Summary

UI/UX polish pass on the transfer workflow, following up the v0.1.8 daisyUI redesign:

- **Hero CTAs**: full-width primary actions (`cta-primary`) for Start / Cancel / "Start another transfer"; the Send button now reads "Send N files" when paths are staged.
- **Status pill**: compact color-coded status pill in the footer (pulsing dot while transferring, `aria-live="polite"`), replacing the plain workflow-status line.
- **Compact status log**: new `appendLogLine` util collapses consecutive duplicate croc output lines into a `×N` counter (log capped at 200 lines), with 8 new vitest cases in `logUtils.test.ts`.
- **Motion**: staggered panel entrances, button hover/press feedback, smooth progress-bar fill, modal pop-in, status-pill color cross-fades.
- **Chevrons**: collapsible toggles (Options, Advanced network, Recent transfers, Status log) render a static `▸` rotated open via `[aria-expanded]` CSS.
- **Footer consolidation**: credits moved into the About dialog (schollz/croc, GUI repo, Credits links); "Clear history" moved inside the collapsible history block.

## Type

- [x] Feature

## Test plan

- [x] `cd gui && npm run build`
- [x] `cd gui && npm run test:rust` (39 passed)
- [x] `cd gui && npm test` (51 vitest cases, incl. 8 new `logUtils` tests)
- [ ] Manual: Send and/or Receive smoke test (if UI changed)

## Notes

- Frontend-only change (`gui/src/App.tsx`, `gui/src/App.css`, new `gui/src/logUtils.ts` + tests); no Rust/backend modifications.
- History note: this commit briefly landed on `main` directly and was moved here via force-push so it goes through review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Refreshed the interface with clearer controls, animated status indicators, improved panels, and a redesigned footer.
  * Added convenient post-transfer actions to start a new transfer or resend the same files.
  * Added repository and credits links in the application footer.
  * Transfer logs now collapse consecutive duplicates and retain a manageable number of entries.

* **Bug Fixes**
  * Improved log handling to prevent excessive or repetitive output.

* **Tests**
  * Added coverage for duplicate handling, log limits, and custom retention settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Polish transfer UI with hero CTAs, status pill, motion, and compact logs
> - Adds full-width primary CTA buttons for key transfer actions (send, receive, cancel); the Start transfer button dynamically shows the selected file count.
> - Introduces an animated status pill in the footer that shows a pulsing dot during active transfers, replacing the separate workflow-status paragraph.
> - Adds rise/pop-in motion animations to the header, footer, and main panels with staggered delays; respects `prefers-reduced-motion`.
> - Collapses consecutive duplicate log lines with a `×N` suffix via a new [`logUtils.ts`](https://github.com/interfluve-wav/croc-gui/pull/7/files#diff-537a93e90bb85b2314a20e776310113aa32821ce6f6140dd811bf78cf9c6660c) utility, capped at 200 lines; covered by unit tests in [`logUtils.test.ts`](https://github.com/interfluve-wav/croc-gui/pull/7/files#diff-3ff922112673c78aadbf19a0f7be303d65e002fe4c4b5b049fde74ec44869460).
> - Chevron rotation on collapsible sections (options, log, history) is now CSS-driven via `aria-expanded` instead of toggled in JS.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized e54c8b6. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->