### PR TITLE
Adopt croc --json events (schollz/croc#1237)

### DIFF
--- a/gui/src-tauri/src/croc.rs
+++ b/gui/src-tauri/src/croc.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 use std::fs::{self, File};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 use zip::write::SimpleFileOptions;
 use zip::{CompressionMethod, ZipWriter};
@@ -10,6 +11,63 @@ use zip::{CompressionMethod, ZipWriter};
 /// Public croc relay used by getcroc.com (must match for web → app transfers).
 pub const DEFAULT_RELAY: &str = "ipv4.getcroc.com:9009";
 pub const DEFAULT_RELAY_PASS: &str = "pass123";
+
+/// Cached result of probing whether the bundled croc binary accepts `--json`.
+/// Populated by `croc_supports_json()`.
+static CROC_SUPPORTS_JSON: OnceLock<bool> = OnceLock::new();
+
+/// Returns `true` if the bundled croc binary accepts `--json`. The result
+/// is cached after the first successful probe; if the probe fails (binary
+/// missing, version unknown), we conservatively return `false` so the GUI
+/// falls back to the regex parser.
+pub fn croc_supports_json() -> bool {
+    *CROC_SUPPORTS_JSON.get_or_init(|| {
+        let Some(bin) = current_croc_bin() else {
+            return false;
+        };
+        probe_croc_json(&bin).unwrap_or(false)
+    })
+}
+
+/// Internal: resolve the croc binary from `CROC_BIN` env, falling back to
+/// the well-known dev path. We intentionally avoid the Tauri resource_dir
+/// resolution here because this runs in a synchronous test context.
+fn current_croc_bin() -> Option<std::path::PathBuf> {
+    if let Ok(p) = std::env::var("CROC_BIN") {
+        let path = std::path::PathBuf::from(p);
+        if path.is_file() {
+            return Some(path);
+        }
+    }
+    let dev_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("bin")
+        .join(if cfg!(windows) { "croc.exe" } else { "croc" });
+    if dev_path.is_file() {
+        return Some(dev_path);
+    }
+    None
+}
+
+/// Probe the croc binary to see if it accepts `--json`. We do this by
+/// invoking `croc --json send --help` and checking if croc treats `--json`
+/// as a known flag. croc v10 will reject with "flag provided but not
+/// defined" and exit non-zero; croc v11+ will exit 0 and show the help text.
+fn probe_croc_json(bin: &std::path::Path) -> Option<bool> {
+    use std::process::Command;
+    let out = Command::new(bin)
+        .args(["--json", "send", "--help"])
+        .output()
+        .ok()?;
+    if out.status.success() {
+        return Some(true);
+    }
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    if stderr.contains("flag provided but not defined") {
+        return Some(false);
+    }
+    // Unknown failure — be conservative.
+    None
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -37,6 +95,15 @@ pub struct TransferOptions {
     /// HTTP proxy (`croc --connect` / `$HTTP_PROXY`).
     #[serde(default)]
     pub connect: Option<String>,
+    /// Use croc's `--json` mode for machine-readable events. Requires croc v11+
+    /// (the feature was added in schollz/croc#1237). Older croc binaries will
+    /// fall back to the regex-based parser in `progress.rs`.
+    #[serde(default = "default_true")]
+    pub use_json_events: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -423,6 +490,11 @@ pub fn build_args(req: &StartTransferRequest) -> Result<Vec<String>, String> {
     if opts.overwrite || is_receive {
         args.push("--overwrite".into());
     }
+    // Request machine-readable NDJSON events from croc v11+ (schollz/croc#1237).
+    // Older croc versions reject unknown flags — `croc_supports_json` gates this.
+    if opts.use_json_events && croc_supports_json() {
+        args.push("--json".into());
+    }
     if is_receive {
         args.push("--ignore-stdin".into());
     }
@@ -669,6 +741,7 @@ mod tests {
             pass: None,
             socks5: None,
             connect: None,
+            use_json_events: false, // test against the non-JSON arg set
         }
     }
 
@@ -1224,5 +1297,66 @@ mod tests {
             None => std::env::remove_var("CROC_BIN"),
         }
         let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn build_args_omits_json_when_disabled() {
+        // Default opts() already sets use_json_events: false, so --json
+        // must not appear even when the binary supports it.
+        let req = StartTransferRequest {
+            mode: TransferMode::Send,
+            paths: vec!["/tmp/x.txt".into()],
+            code: None,
+            out_dir: None,
+            options: opts(),
+        };
+        let args = build_args(&req).unwrap();
+        assert!(
+            !args.contains(&"--json".to_string()),
+            "--json should not be present when use_json_events=false; got: {:?}",
+            args
+        );
+    }
+
+    #[test]
+    fn probe_croc_json_detects_v10_rejection() {
+        // Write a fake "croc" that rejects --json with the v10 error string.
+        let tmp = std::env::temp_dir().join(format!("fake-croc-{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let bin = tmp.join(if cfg!(windows) { "croc.exe" } else { "croc" });
+        std::fs::write(
+            &bin,
+            "#!/bin/sh\necho 'flag provided but not defined: -json' >&2\nexit 1\n",
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        let result = probe_croc_json(&bin);
+        let _ = std::fs::remove_dir_all(&tmp);
+        assert_eq!(result, Some(false));
+    }
+
+    #[test]
+    fn probe_croc_json_detects_v11_acceptance() {
+        // Write a fake "croc" that exits 0 when given --json.
+        let tmp = std::env::temp_dir().join(format!("fake-croc-ok-{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let bin = tmp.join(if cfg!(windows) { "croc.exe" } else { "croc" });
+        std::fs::write(
+            &bin,
+            "#!/bin/sh\necho 'croc send [options] [files]' >&2\nexit 0\n",
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        let result = probe_croc_json(&bin);
+        let _ = std::fs::remove_dir_all(&tmp);
+        assert_eq!(result, Some(true));
     }
 }

--- a/gui/src-tauri/src/croc.rs
+++ b/gui/src-tauri/src/croc.rs
@@ -1,9 +1,9 @@
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs::{self, File};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use std::sync::OnceLock;
+use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
 use zip::write::SimpleFileOptions;
 use zip::{CompressionMethod, ZipWriter};
@@ -12,40 +12,26 @@ use zip::{CompressionMethod, ZipWriter};
 pub const DEFAULT_RELAY: &str = "ipv4.getcroc.com:9009";
 pub const DEFAULT_RELAY_PASS: &str = "pass123";
 
-/// Cached result of probing whether the bundled croc binary accepts `--json`.
-/// Populated by `croc_supports_json()`.
-static CROC_SUPPORTS_JSON: OnceLock<bool> = OnceLock::new();
+/// Cached results of probing whether specific croc binaries accept `--json`.
+/// Maps absolute path → capability. Each distinct binary is probed once.
+static CROC_JSON_CACHE: Mutex<HashMap<PathBuf, bool>> = Mutex::new(HashMap::new());
 
-/// Returns `true` if the bundled croc binary accepts `--json`. The result
-/// is cached after the first successful probe; if the probe fails (binary
-/// missing, version unknown), we conservatively return `false` so the GUI
-/// falls back to the regex parser.
-pub fn croc_supports_json() -> bool {
-    *CROC_SUPPORTS_JSON.get_or_init(|| {
-        let Some(bin) = current_croc_bin() else {
-            return false;
-        };
-        probe_croc_json(&bin).unwrap_or(false)
-    })
-}
-
-/// Internal: resolve the croc binary from `CROC_BIN` env, falling back to
-/// the well-known dev path. We intentionally avoid the Tauri resource_dir
-/// resolution here because this runs in a synchronous test context.
-fn current_croc_bin() -> Option<std::path::PathBuf> {
-    if let Ok(p) = std::env::var("CROC_BIN") {
-        let path = std::path::PathBuf::from(p);
-        if path.is_file() {
-            return Some(path);
+/// Returns `true` if the croc binary at `path` accepts `--json`. The result
+/// is cached per executable path; if the probe fails (binary missing, version
+/// unknown), we conservatively return `false` so the GUI falls back to the
+/// regex parser.
+pub fn croc_supports_json(path: &Path) -> bool {
+    if let Ok(mut cache) = CROC_JSON_CACHE.lock() {
+        if let Some(&result) = cache.get(path) {
+            return result;
         }
+        let result = probe_croc_json(path).unwrap_or(false);
+        cache.insert(path.to_path_buf(), result);
+        result
+    } else {
+        // Poisoned mutex — safe fallback.
+        probe_croc_json(path).unwrap_or(false)
     }
-    let dev_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("bin")
-        .join(if cfg!(windows) { "croc.exe" } else { "croc" });
-    if dev_path.is_file() {
-        return Some(dev_path);
-    }
-    None
 }
 
 /// Probe the croc binary to see if it accepts `--json`. We do this by
@@ -479,7 +465,10 @@ pub fn resolve_relay_options(opts: &TransferOptions) -> (Option<String>, Option<
     }
 }
 
-pub fn build_args(req: &StartTransferRequest) -> Result<Vec<String>, String> {
+pub fn build_args(
+    req: &StartTransferRequest,
+    resolved_bin: &Path,
+) -> Result<Vec<String>, String> {
     let mut args: Vec<String> = Vec::new();
     let opts = &req.options;
     let is_receive = matches!(req.mode, TransferMode::Receive);
@@ -492,7 +481,7 @@ pub fn build_args(req: &StartTransferRequest) -> Result<Vec<String>, String> {
     }
     // Request machine-readable NDJSON events from croc v11+ (schollz/croc#1237).
     // Older croc versions reject unknown flags — `croc_supports_json` gates this.
-    if opts.use_json_events && croc_supports_json() {
+    if opts.use_json_events && croc_supports_json(resolved_bin) {
         args.push("--json".into());
     }
     if is_receive {
@@ -728,6 +717,10 @@ pub fn extract_code_phrase(line: &str) -> Option<String> {
 mod tests {
     use super::*;
 
+    fn dummy_bin_path() -> PathBuf {
+        PathBuf::from("/tmp/croc")
+    }
+
     fn opts() -> TransferOptions {
         TransferOptions {
             custom_code: None,
@@ -763,7 +756,7 @@ mod tests {
             out_dir: None,
             options: opts(),
         };
-        let args = build_args(&req).unwrap();
+        let args = build_args(&req, &dummy_bin_path()).unwrap();
         let expected = default_relay_args();
         assert_eq!(
             args,
@@ -787,7 +780,7 @@ mod tests {
             out_dir: None,
             options,
         };
-        let args = build_args(&req).unwrap();
+        let args = build_args(&req, &dummy_bin_path()).unwrap();
         let expected = default_relay_args();
         assert_eq!(
             args,
@@ -889,7 +882,7 @@ mod tests {
             out_dir: None,
             options,
         };
-        let args = build_args(&req).unwrap();
+        let args = build_args(&req, &dummy_bin_path()).unwrap();
         assert_eq!(
             args,
             vec![
@@ -924,7 +917,7 @@ mod tests {
             out_dir: None,
             options,
         };
-        let args = build_args(&req).unwrap();
+        let args = build_args(&req, &dummy_bin_path()).unwrap();
         assert_eq!(
             args,
             vec![
@@ -998,7 +991,7 @@ mod tests {
             out_dir: None,
             options,
         };
-        let args = build_args(&req).unwrap();
+        let args = build_args(&req, &dummy_bin_path()).unwrap();
         let expected = default_relay_args();
         assert_eq!(
             args,
@@ -1029,7 +1022,7 @@ mod tests {
             out_dir: None,
             options,
         };
-        let args = build_args(&req).unwrap();
+        let args = build_args(&req, &dummy_bin_path()).unwrap();
         assert!(!args.iter().any(|a| a == "--socks5" || a == "--connect"));
     }
 
@@ -1044,7 +1037,7 @@ mod tests {
             out_dir: None,
             options,
         };
-        let args = build_args(&req).unwrap();
+        let args = build_args(&req, &dummy_bin_path()).unwrap();
         assert_eq!(args, vec!["--local", "send", "/tmp/a.txt"]);
     }
 
@@ -1059,7 +1052,7 @@ mod tests {
             out_dir: Some("/tmp/inbox".into()),
             options,
         };
-        let args = build_args(&req).unwrap();
+        let args = build_args(&req, &dummy_bin_path()).unwrap();
         assert_eq!(
             args,
             vec![
@@ -1084,7 +1077,7 @@ mod tests {
             out_dir: None,
             options,
         };
-        assert!(build_args(&req).is_err());
+        assert!(build_args(&req, &dummy_bin_path()).is_err());
     }
 
     #[test]
@@ -1096,7 +1089,7 @@ mod tests {
             out_dir: None,
             options: opts(),
         };
-        assert!(build_args(&req).is_err());
+        assert!(build_args(&req, &dummy_bin_path()).is_err());
     }
 
     #[test]
@@ -1108,7 +1101,7 @@ mod tests {
             out_dir: Some("/tmp/inbox".into()),
             options: opts(),
         };
-        let args = build_args(&req).unwrap();
+        let args = build_args(&req, &dummy_bin_path()).unwrap();
         assert_eq!(
             args,
             vec![
@@ -1136,7 +1129,7 @@ mod tests {
             out_dir: None,
             options,
         };
-        let args = build_args(&req).unwrap();
+        let args = build_args(&req, &dummy_bin_path()).unwrap();
         assert!(args.contains(&"--pass".to_string()));
         assert!(args.contains(&DEFAULT_RELAY_PASS.to_string()));
         assert!(args.contains(&DEFAULT_RELAY.to_string()));
@@ -1154,7 +1147,7 @@ mod tests {
             out_dir: Some("/tmp/inbox".into()),
             options,
         };
-        let args = build_args(&req).unwrap();
+        let args = build_args(&req, &dummy_bin_path()).unwrap();
         assert!(args.contains(&"--pass".to_string()));
         assert!(args.contains(&DEFAULT_RELAY_PASS.to_string()));
         assert!(args.contains(&DEFAULT_RELAY.to_string()));
@@ -1181,7 +1174,7 @@ mod tests {
             out_dir: None,
             options,
         };
-        assert!(build_args(&req).is_err());
+        assert!(build_args(&req, &dummy_bin_path()).is_err());
     }
 
     fn receive_requires_out_dir() {
@@ -1192,7 +1185,7 @@ mod tests {
             out_dir: None,
             options: opts(),
         };
-        assert!(build_args(&req).is_err());
+        assert!(build_args(&req, &dummy_bin_path()).is_err());
     }
 
     #[test]
@@ -1204,7 +1197,7 @@ mod tests {
             out_dir: None,
             options: opts(),
         };
-        assert!(build_args(&req).is_err());
+        assert!(build_args(&req, &dummy_bin_path()).is_err());
     }
 
     #[test]
@@ -1310,7 +1303,7 @@ mod tests {
             out_dir: None,
             options: opts(),
         };
-        let args = build_args(&req).unwrap();
+        let args = build_args(&req, &dummy_bin_path()).unwrap();
         assert!(
             !args.contains(&"--json".to_string()),
             "--json should not be present when use_json_events=false; got: {:?}",

--- a/gui/src-tauri/src/croc.rs
+++ b/gui/src-tauri/src/croc.rs
@@ -3,7 +3,6 @@ use std::collections::{HashMap, HashSet};
 use std::fs::{self, File};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
 use zip::write::SimpleFileOptions;
 use zip::{CompressionMethod, ZipWriter};
@@ -14,7 +13,8 @@ pub const DEFAULT_RELAY_PASS: &str = "pass123";
 
 /// Cached results of probing whether specific croc binaries accept `--json`.
 /// Maps absolute path → capability. Each distinct binary is probed once.
-static CROC_JSON_CACHE: Mutex<HashMap<PathBuf, bool>> = Mutex::new(HashMap::new());
+static CROC_JSON_CACHE: std::sync::LazyLock<std::sync::Mutex<HashMap<PathBuf, bool>>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(HashMap::new()));
 
 /// Returns `true` if the croc binary at `path` accepts `--json`. The result
 /// is cached per executable path; if the probe fails (binary missing, version
@@ -1351,5 +1351,48 @@ mod tests {
         let result = probe_croc_json(&bin);
         let _ = std::fs::remove_dir_all(&tmp);
         assert_eq!(result, Some(true));
+    }
+
+    #[test]
+    fn croc_supports_json_caches_per_path() {
+        // CodeRabbit PR#8: verify the per-path cache gives each croc
+        // binary its own result — a v10 binary on PATH must not poison
+        // the v11+ bundled binary's cached value (or vice versa).
+        let tmp = std::env::temp_dir().join(format!("fake-croc-cache-{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let bin_name = if cfg!(windows) { "croc.exe" } else { "croc" };
+        let v10 = tmp.join(format!("v10-{bin_name}"));
+        let v11 = tmp.join(format!("v11-{bin_name}"));
+        std::fs::write(
+            &v10,
+            "#!/bin/sh\necho 'flag provided but not defined: -json' >&2\nexit 1\n",
+        )
+        .unwrap();
+        std::fs::write(
+            &v11,
+            "#!/bin/sh\necho 'croc send [options] [files]' >&2\nexit 0\n",
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&v10, std::fs::Permissions::from_mode(0o755)).unwrap();
+            std::fs::set_permissions(&v11, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        assert_eq!(
+            croc_supports_json(&v10),
+            false,
+            "v10 binary should be detected as not supporting --json"
+        );
+        assert_eq!(
+            croc_supports_json(&v11),
+            true,
+            "v11 binary should be detected as supporting --json"
+        );
+        // Re-probe — should hit the per-path cache without re-execing
+        // the binary.
+        assert_eq!(croc_supports_json(&v10), false);
+        assert_eq!(croc_supports_json(&v11), true);
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 }

--- a/gui/src-tauri/src/events.rs
+++ b/gui/src-tauri/src/events.rs
@@ -1,0 +1,334 @@
+//! Machine-readable croc event consumer.
+//!
+//! Reads newline-delimited JSON events from croc's `--json` mode (stderr) and
+//! maps them to Tauri-friendly payload structs. Falls back gracefully on
+//! non-JSON lines (older croc versions, or pre-handshake status output).
+//!
+//! Event source: <https://github.com/schollz/croc/pull/1237> (croc v11+).
+//!
+//! Each event type from croc maps to a Tauri event:
+//!   `version`  → `transfer-version` (informational, not currently emitted by Tauri)
+//!   `code`     → `transfer-code` (sender only; the secret phrase)
+//!   `phase`    → `transfer-phase` (hashing / connecting / transferring / complete)
+//!   `progress` → `transfer-progress-v2` (bytesTransferred/bytesTotal/percent/speedBps)
+//!   `complete` → `transfer-complete` (file list, success)
+//!   `error`    → `transfer-error` (code + message + hint)
+//!   `store`    → `transfer-store` (stored-transfer details; not yet surfaced)
+//!
+//! We keep the old `transfer-progress` (regex-parsed) and `transfer-line` (raw
+//! text) events running in parallel so App.tsx can migrate at its own pace
+//! and so we have a fallback if `--json` is rejected by an older croc.
+
+use serde::{Deserialize, Serialize};
+use std::io::{BufRead, BufReader, Read};
+
+/// Raw croc event from the wire. Tolerant of extra/missing fields so a
+/// future croc release adding a new field doesn't break the parser.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[serde(rename_all_fields = "camelCase")]
+pub enum CrocEvent {
+    Version {
+        version: String,
+    },
+    Code {
+        code: String,
+    },
+    #[serde(alias = "phase")]
+    Phase {
+        phase: String,
+        #[serde(default)]
+        message: Option<String>,
+    },
+    Progress {
+        #[serde(default)]
+        file: Option<String>,
+        bytes_transferred: i64,
+        bytes_total: i64,
+        percent: f64,
+        speed_bps: i64,
+    },
+    Complete {
+        #[serde(default)]
+        files: Vec<CompleteFile>,
+    },
+    Error {
+        code: String,
+        message: String,
+        #[serde(default)]
+        hint: Option<String>,
+    },
+    #[allow(dead_code)]
+    Store {
+        #[serde(default)]
+        url: Option<String>,
+        #[serde(default)]
+        token: Option<String>,
+        #[serde(default)]
+        expires_at: Option<String>,
+        #[serde(default)]
+        revoke_id: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CompleteFile {
+    pub name: String,
+    pub bytes: i64,
+}
+
+/// Tauri-facing payload for `transfer-progress-v2`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TransferProgressV2 {
+    pub percent: f64,
+    pub bytes_done: i64,
+    pub bytes_total: i64,
+    pub speed_bps: i64,
+    pub file: Option<String>,
+}
+
+impl From<CrocEvent> for Option<TransferProgressV2> {
+    fn from(ev: CrocEvent) -> Self {
+        match ev {
+            CrocEvent::Progress {
+                file,
+                bytes_transferred,
+                bytes_total,
+                percent,
+                speed_bps,
+            } => Some(TransferProgressV2 {
+                percent,
+                bytes_done: bytes_transferred,
+                bytes_total,
+                speed_bps,
+                file,
+            }),
+            _ => None,
+        }
+    }
+}
+
+/// Tauri-facing payload for `transfer-phase`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TransferPhase {
+    pub phase: String,
+    pub message: Option<String>,
+}
+
+/// Tauri-facing payload for `transfer-error`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TransferError {
+    pub code: String,
+    pub message: String,
+    pub hint: Option<String>,
+}
+
+/// Tauri-facing payload for `transfer-complete`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TransferComplete {
+    pub files: Vec<CompleteFile>,
+}
+
+/// Callback invoked for each parsed event. Tauri emission is handled by the
+/// caller via this closure so this module stays UI-agnostic.
+pub trait EventSink: Send + 'static {
+    fn on_code(&mut self, code: String);
+    fn on_phase(&mut self, phase: TransferPhase);
+    fn on_progress(&mut self, progress: TransferProgressV2);
+    fn on_complete(&mut self, complete: TransferComplete);
+    fn on_error(&mut self, error: TransferError);
+    fn on_unparsed(&mut self, raw_line: String);
+}
+
+/// Pump an NDJSON stream from croc's stderr. Each line is parsed as JSON;
+/// non-JSON lines are forwarded via `on_unparsed` so the existing log
+/// consumer still sees them (covers the brief pre-handshake window where
+/// croc may print non-JSON status text).
+pub fn pump_json_stream<R: Read + Send + 'static>(reader: R, mut sink: Box<dyn EventSink>) {
+    std::thread::spawn(move || {
+        pump_json_stream_sync(reader, sink.as_mut());
+    });
+}
+
+/// Synchronous variant. Useful in tests and for callers that already have
+/// a worker thread. Reads the entire stream to EOF, dispatching to `sink`.
+pub fn pump_json_stream_sync<R: Read>(reader: R, sink: &mut dyn EventSink) {
+    let buf = BufReader::new(reader);
+    for line in buf.lines() {
+        let Ok(line) = line else { break };
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        dispatch(trimmed, sink);
+    }
+}
+
+fn dispatch(trimmed: &str, sink: &mut dyn EventSink) {
+    match serde_json::from_str::<CrocEvent>(trimmed) {
+        Ok(ev) => match ev {
+            CrocEvent::Code { code } => sink.on_code(code),
+            CrocEvent::Phase { phase, message } => {
+                sink.on_phase(TransferPhase { phase, message });
+            }
+            CrocEvent::Progress {
+                file,
+                bytes_transferred,
+                bytes_total,
+                percent,
+                speed_bps,
+            } => sink.on_progress(TransferProgressV2 {
+                percent,
+                bytes_done: bytes_transferred,
+                bytes_total,
+                speed_bps,
+                file,
+            }),
+            CrocEvent::Complete { files } => {
+                sink.on_complete(TransferComplete { files });
+            }
+            CrocEvent::Error {
+                code,
+                message,
+                hint,
+            } => sink.on_error(TransferError {
+                code,
+                message,
+                hint,
+            }),
+            CrocEvent::Version { .. } => {
+                // Informational only; no Tauri surface yet.
+            }
+            CrocEvent::Store { .. } => {
+                // Stored-transfer details; will surface in a follow-up.
+            }
+        },
+        Err(_) => sink.on_unparsed(trimmed.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+    use std::sync::{Arc, Mutex};
+
+    /// In-memory sink for tests.
+    #[derive(Default, Clone)]
+    struct CapturedEvents {
+        codes: Arc<Mutex<Vec<String>>>,
+        phases: Arc<Mutex<Vec<TransferPhase>>>,
+        progresses: Arc<Mutex<Vec<TransferProgressV2>>>,
+        completes: Arc<Mutex<Vec<TransferComplete>>>,
+        errors: Arc<Mutex<Vec<TransferError>>>,
+        unparsed: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl EventSink for CapturedEvents {
+        fn on_code(&mut self, code: String) {
+            self.codes.lock().unwrap().push(code);
+        }
+        fn on_phase(&mut self, phase: TransferPhase) {
+            self.phases.lock().unwrap().push(phase);
+        }
+        fn on_progress(&mut self, progress: TransferProgressV2) {
+            self.progresses.lock().unwrap().push(progress);
+        }
+        fn on_complete(&mut self, complete: TransferComplete) {
+            self.completes.lock().unwrap().push(complete);
+        }
+        fn on_error(&mut self, error: TransferError) {
+            self.errors.lock().unwrap().push(error);
+        }
+        fn on_unparsed(&mut self, raw_line: String) {
+            self.unparsed.lock().unwrap().push(raw_line);
+        }
+    }
+
+    /// Synchronous version for deterministic test assertions. Drains the
+    /// reader inline so the test can immediately inspect the captured
+    /// events without sleeping.
+    fn run_sync<R: std::io::Read>(reader: R) -> CapturedEvents {
+        let mut cap = CapturedEvents::default();
+        pump_json_stream_sync(reader, &mut cap);
+        cap
+    }
+
+    #[test]
+    fn parses_full_sender_stream() {
+        let input = r#"{"type":"version","version":"11.1.0"}
+{"type":"code","code":"mango-lake-42"}
+{"type":"phase","phase":"hashing","message":"hashing files"}
+{"type":"phase","phase":"connecting","message":"connecting to relay"}
+{"type":"phase","phase":"transferring","message":"transferring files"}
+{"type":"progress","file":"hello.txt","bytesTransferred":80,"bytesTotal":80,"percent":100.0,"speedBps":0}
+{"type":"complete","files":[{"name":"hello.txt","bytes":80}]}
+{"type":"phase","phase":"complete","message":"transfer complete"}
+"#;
+        let cap = run_sync(Cursor::new(input));
+
+        assert_eq!(cap.codes.lock().unwrap().as_slice(), &["mango-lake-42"]);
+        let phases = cap.phases.lock().unwrap();
+        assert_eq!(phases.len(), 4);
+        assert_eq!(phases[0].phase, "hashing");
+        assert_eq!(phases[3].phase, "complete");
+
+        let progresses = cap.progresses.lock().unwrap();
+        assert_eq!(progresses.len(), 1);
+        assert_eq!(progresses[0].bytes_done, 80);
+        assert_eq!(progresses[0].bytes_total, 80);
+        assert_eq!(progresses[0].file.as_deref(), Some("hello.txt"));
+
+        let completes = cap.completes.lock().unwrap();
+        assert_eq!(completes.len(), 1);
+        assert_eq!(completes[0].files.len(), 1);
+        assert_eq!(completes[0].files[0].name, "hello.txt");
+        assert_eq!(completes[0].files[0].bytes, 80);
+
+        assert!(cap.unparsed.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn parses_error_event() {
+        let input = r#"{"type":"version","version":"11.1.0"}
+{"type":"phase","phase":"connecting","message":"connecting to relay"}
+{"type":"error","code":"auth_failed","message":"cipher: message authentication failed","hint":"make sure both sides use the same code phrase and relay password"}
+"#;
+        let cap = run_sync(Cursor::new(input));
+
+        let errors = cap.errors.lock().unwrap();
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].code, "auth_failed");
+        assert_eq!(
+            errors[0].hint.as_deref(),
+            Some("make sure both sides use the same code phrase and relay password")
+        );
+    }
+
+    #[test]
+    fn non_json_lines_fall_through_to_unparsed() {
+        let input = "Connecting to relay...\nthis is not json\n{\"type\":\"phase\",\"phase\":\"transferring\"}\n";
+        let cap = run_sync(Cursor::new(input));
+
+        let unparsed = cap.unparsed.lock().unwrap();
+        assert_eq!(
+            unparsed.as_slice(),
+            &["Connecting to relay...", "this is not json"]
+        );
+        let phases = cap.phases.lock().unwrap();
+        assert_eq!(phases.len(), 1);
+        assert_eq!(phases[0].phase, "transferring");
+    }
+
+    #[test]
+    fn empty_lines_are_ignored() {
+        let input = "\n\n{\"type\":\"phase\",\"phase\":\"transferring\"}\n\n";
+        let cap = run_sync(Cursor::new(input));
+        assert_eq!(cap.phases.lock().unwrap().len(), 1);
+        assert!(cap.unparsed.lock().unwrap().is_empty());
+    }
+}

--- a/gui/src-tauri/src/events.rs
+++ b/gui/src-tauri/src/events.rs
@@ -98,6 +98,16 @@ pub struct TransferPhase {
     pub session_id: u64,
 }
 
+/// Tauri-facing payload for `transfer-code`. Carries `session_id` so the
+/// frontend can reject stale code phrases from a cancelled transfer that
+/// race against a new one (Macroscope PR#8 review).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TransferCode {
+    pub code: String,
+    pub session_id: u64,
+}
+
 /// Tauri-facing payload for `transfer-error`.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -120,7 +130,7 @@ pub struct TransferComplete {
 /// caller via this closure so this module stays UI-agnostic.
 pub trait EventSink: Send + 'static {
     fn session_id(&self) -> u64;
-    fn on_code(&mut self, code: String);
+    fn on_code(&mut self, code: TransferCode);
     fn on_phase(&mut self, phase: TransferPhase);
     fn on_progress(&mut self, progress: TransferProgressV2);
     fn on_complete(&mut self, complete: TransferComplete);
@@ -156,7 +166,9 @@ fn dispatch(trimmed: &str, sink: &mut dyn EventSink) {
     let session_id = sink.session_id();
     match serde_json::from_str::<CrocEvent>(trimmed) {
         Ok(ev) => match ev {
-            CrocEvent::Code { code } => sink.on_code(code),
+            CrocEvent::Code { code } => {
+                sink.on_code(TransferCode { code, session_id })
+            }
             CrocEvent::Phase { phase, message } => {
                 sink.on_phase(TransferPhase {
                     phase,
@@ -211,7 +223,7 @@ mod tests {
     /// In-memory sink for tests.
     #[derive(Default, Clone)]
     struct CapturedEvents {
-        codes: Arc<Mutex<Vec<String>>>,
+        codes: Arc<Mutex<Vec<TransferCode>>>,
         phases: Arc<Mutex<Vec<TransferPhase>>>,
         progresses: Arc<Mutex<Vec<TransferProgressV2>>>,
         completes: Arc<Mutex<Vec<TransferComplete>>>,
@@ -224,7 +236,7 @@ mod tests {
             // Test fixture: use a constant session ID.
             1
         }
-        fn on_code(&mut self, code: String) {
+        fn on_code(&mut self, code: TransferCode) {
             self.codes.lock().unwrap().push(code);
         }
         fn on_phase(&mut self, phase: TransferPhase) {
@@ -266,7 +278,10 @@ mod tests {
 "#;
         let cap = run_sync(Cursor::new(input));
 
-        assert_eq!(cap.codes.lock().unwrap().as_slice(), &["mango-lake-42"]);
+        let codes = cap.codes.lock().unwrap();
+        assert_eq!(codes.len(), 1);
+        assert_eq!(codes[0].code, "mango-lake-42");
+        assert_eq!(codes[0].session_id, 1, "code event must carry session id");
         let phases = cap.phases.lock().unwrap();
         assert_eq!(phases.len(), 4);
         assert_eq!(phases[0].phase, "hashing");

--- a/gui/src-tauri/src/events.rs
+++ b/gui/src-tauri/src/events.rs
@@ -86,27 +86,7 @@ pub struct TransferProgressV2 {
     pub bytes_total: i64,
     pub speed_bps: i64,
     pub file: Option<String>,
-}
-
-impl From<CrocEvent> for Option<TransferProgressV2> {
-    fn from(ev: CrocEvent) -> Self {
-        match ev {
-            CrocEvent::Progress {
-                file,
-                bytes_transferred,
-                bytes_total,
-                percent,
-                speed_bps,
-            } => Some(TransferProgressV2 {
-                percent,
-                bytes_done: bytes_transferred,
-                bytes_total,
-                speed_bps,
-                file,
-            }),
-            _ => None,
-        }
-    }
+    pub session_id: u64,
 }
 
 /// Tauri-facing payload for `transfer-phase`.
@@ -115,6 +95,7 @@ impl From<CrocEvent> for Option<TransferProgressV2> {
 pub struct TransferPhase {
     pub phase: String,
     pub message: Option<String>,
+    pub session_id: u64,
 }
 
 /// Tauri-facing payload for `transfer-error`.
@@ -124,6 +105,7 @@ pub struct TransferError {
     pub code: String,
     pub message: String,
     pub hint: Option<String>,
+    pub session_id: u64,
 }
 
 /// Tauri-facing payload for `transfer-complete`.
@@ -131,11 +113,13 @@ pub struct TransferError {
 #[serde(rename_all = "camelCase")]
 pub struct TransferComplete {
     pub files: Vec<CompleteFile>,
+    pub session_id: u64,
 }
 
 /// Callback invoked for each parsed event. Tauri emission is handled by the
 /// caller via this closure so this module stays UI-agnostic.
 pub trait EventSink: Send + 'static {
+    fn session_id(&self) -> u64;
     fn on_code(&mut self, code: String);
     fn on_phase(&mut self, phase: TransferPhase);
     fn on_progress(&mut self, progress: TransferProgressV2);
@@ -169,11 +153,16 @@ pub fn pump_json_stream_sync<R: Read>(reader: R, sink: &mut dyn EventSink) {
 }
 
 fn dispatch(trimmed: &str, sink: &mut dyn EventSink) {
+    let session_id = sink.session_id();
     match serde_json::from_str::<CrocEvent>(trimmed) {
         Ok(ev) => match ev {
             CrocEvent::Code { code } => sink.on_code(code),
             CrocEvent::Phase { phase, message } => {
-                sink.on_phase(TransferPhase { phase, message });
+                sink.on_phase(TransferPhase {
+                    phase,
+                    message,
+                    session_id,
+                });
             }
             CrocEvent::Progress {
                 file,
@@ -187,9 +176,10 @@ fn dispatch(trimmed: &str, sink: &mut dyn EventSink) {
                 bytes_total,
                 speed_bps,
                 file,
+                session_id,
             }),
             CrocEvent::Complete { files } => {
-                sink.on_complete(TransferComplete { files });
+                sink.on_complete(TransferComplete { files, session_id });
             }
             CrocEvent::Error {
                 code,
@@ -199,6 +189,7 @@ fn dispatch(trimmed: &str, sink: &mut dyn EventSink) {
                 code,
                 message,
                 hint,
+                session_id,
             }),
             CrocEvent::Version { .. } => {
                 // Informational only; no Tauri surface yet.
@@ -229,6 +220,10 @@ mod tests {
     }
 
     impl EventSink for CapturedEvents {
+        fn session_id(&self) -> u64 {
+            // Test fixture: use a constant session ID.
+            1
+        }
         fn on_code(&mut self, code: String) {
             self.codes.lock().unwrap().push(code);
         }

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -7,7 +7,7 @@ use croc::{
     resolve_relay_options, sanitize_code_phrase, zip_new_entries, StartTransferRequest,
     TransferMode, DEFAULT_RELAY,
 };
-use events::{EventSink, TransferComplete, TransferError, TransferPhase, TransferProgressV2};
+use events::{EventSink, TransferCode, TransferComplete, TransferError, TransferPhase, TransferProgressV2};
 use progress::parse_progress_line;
 use serde::Serialize;
 use std::collections::HashSet;
@@ -135,7 +135,7 @@ impl EventSink for TauriEventSink {
     fn session_id(&self) -> u64 {
         self.session_id
     }
-    fn on_code(&mut self, code: String) {
+    fn on_code(&mut self, code: TransferCode) {
         let _ = self.app.emit("transfer-code", code);
     }
     fn on_phase(&mut self, phase: TransferPhase) {

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -128,9 +128,13 @@ fn emit_transfer_output(app: &AppHandle, stream: &str, raw_line: &str) {
 /// shows raw croc output in the log viewer.
 struct TauriEventSink {
     app: AppHandle,
+    session_id: u64,
 }
 
 impl EventSink for TauriEventSink {
+    fn session_id(&self) -> u64 {
+        self.session_id
+    }
     fn on_code(&mut self, code: String) {
         let _ = self.app.emit("transfer-code", code);
     }
@@ -151,14 +155,7 @@ impl EventSink for TauriEventSink {
         // structured parsing raced ahead of the legacy path we still
         // forward the line so nothing is lost, but with stream="stderr-unparsed"
         // so the UI can dedupe if it wants.
-        let _ = self.app.emit(
-            "transfer-line",
-            TransferLinePayload {
-                stream: "stderr-unparsed".into(),
-                line: raw_line,
-                code: None,
-            },
-        );
+        emit_transfer_output(&self.app, "stderr", &raw_line);
     }
 }
 
@@ -330,7 +327,7 @@ fn start_transfer(
         }
     }
 
-    let args = match croc::build_args(&request) {
+    let args = match croc::build_args(&request, &program) {
         Ok(args) => args,
         Err(err) => {
             clear_send_zip_workdir(&state);
@@ -540,6 +537,7 @@ fn start_transfer(
         // `transfer-*` events that the GUI can opt into.
         let json_sink = TauriEventSink {
             app: app_err.clone(),
+            session_id,
         };
         events::pump_json_stream(err, Box::new(json_sink));
     }

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod croc;
+pub mod events;
 mod progress;
 
 use croc::{
@@ -6,6 +7,7 @@ use croc::{
     resolve_relay_options, sanitize_code_phrase, zip_new_entries, StartTransferRequest,
     TransferMode, DEFAULT_RELAY,
 };
+use events::{EventSink, TransferComplete, TransferError, TransferPhase, TransferProgressV2};
 use progress::parse_progress_line;
 use serde::Serialize;
 use std::collections::HashSet;
@@ -117,6 +119,47 @@ fn emit_transfer_output(app: &AppHandle, stream: &str, raw_line: &str) {
             code,
         },
     );
+}
+
+/// Adapter that turns `events::EventSink` callbacks into Tauri emissions.
+/// Used by `start_transfer` when croc was launched with `--json`. The legacy
+/// `transfer-line` log emitter keeps running in parallel via `pump_stream`,
+/// so the GUI has a single source of truth for structured events but still
+/// shows raw croc output in the log viewer.
+struct TauriEventSink {
+    app: AppHandle,
+}
+
+impl EventSink for TauriEventSink {
+    fn on_code(&mut self, code: String) {
+        let _ = self.app.emit("transfer-code", code);
+    }
+    fn on_phase(&mut self, phase: TransferPhase) {
+        let _ = self.app.emit("transfer-phase", phase);
+    }
+    fn on_progress(&mut self, progress: TransferProgressV2) {
+        let _ = self.app.emit("transfer-progress-v2", progress);
+    }
+    fn on_complete(&mut self, complete: TransferComplete) {
+        let _ = self.app.emit("transfer-complete", complete);
+    }
+    fn on_error(&mut self, error: TransferError) {
+        let _ = self.app.emit("transfer-error", error);
+    }
+    fn on_unparsed(&mut self, raw_line: String) {
+        // The legacy pump already emits transfer-line for raw text. If
+        // structured parsing raced ahead of the legacy path we still
+        // forward the line so nothing is lost, but with stream="stderr-unparsed"
+        // so the UI can dedupe if it wants.
+        let _ = self.app.emit(
+            "transfer-line",
+            TransferLinePayload {
+                stream: "stderr-unparsed".into(),
+                line: raw_line,
+                code: None,
+            },
+        );
+    }
 }
 
 fn pump_stream<R: Read + Send + 'static>(reader: R, app: AppHandle, stream: String) {
@@ -491,7 +534,14 @@ fn start_transfer(
 
     let app_err = app.clone();
     if let Some(err) = stderr {
-        pump_stream(err, app_err, "stderr".into());
+        // Always keep the legacy log pump running so the existing log viewer
+        // shows raw croc output. In parallel, feed the same pipe to the
+        // structured event consumer — it parses NDJSON and emits richer
+        // `transfer-*` events that the GUI can opt into.
+        let json_sink = TauriEventSink {
+            app: app_err.clone(),
+        };
+        events::pump_json_stream(err, Box::new(json_sink));
     }
 
     let app_wait = app.clone();

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -9,6 +9,7 @@ import { openUrl, revealItemInDir } from "@tauri-apps/plugin-opener";
 import QRCode from "qrcode";
 import { applyProxyFieldNormalization } from "./proxyPaste";
 import { appendLogLine } from "./logUtils";
+import { formatSpeed } from "./speedFormat";
 import { SharePhraseBlock } from "./components/SharePhraseBlock";
 import { TransferFileList } from "./components/TransferFileList";
 import { TransferProgressBlock } from "./components/TransferProgressBlock";
@@ -90,6 +91,32 @@ type ProgressEvent = {
   speed: string | null;
   phase: string | null;
   label: string | null;
+};
+
+// v2 event types from croc --json (schollz/croc#1237). These are emitted
+// in parallel with the legacy `transfer-progress` / `transfer-line` events
+// so the GUI can migrate at its own pace.
+type ProgressV2Event = {
+  percent: number;
+  bytesDone: number;
+  bytesTotal: number;
+  speedBps: number;
+  file: string | null;
+};
+
+type PhaseV2Event = {
+  phase: string;
+  message: string | null;
+};
+
+type CompleteV2Event = {
+  files: Array<{ name: string; bytes: number }>;
+};
+
+type ErrorV2Event = {
+  code: string;
+  message: string;
+  hint: string | null;
 };
 
 type ProgressState = {
@@ -612,8 +639,101 @@ function App() {
     let unlistenLine: (() => void) | undefined;
     let unlistenExit: (() => void) | undefined;
     let unlistenProgress: (() => void) | undefined;
+    let unlistenCode: (() => void) | undefined;
+    let unlistenPhase: (() => void) | undefined;
+    let unlistenProgressV2: (() => void) | undefined;
+    let unlistenComplete: (() => void) | undefined;
+    let unlistenError: (() => void) | undefined;
 
     (async () => {
+      unlistenCode = await listen<string>("transfer-code", (event) => {
+        // The structured code event from croc --json. Authoritative — the
+        // legacy `transfer-line` "Code is:" regex is broken on v11+, so
+        // this is the only reliable source.
+        const code = event.payload;
+        if (code && typeof code === "string") {
+          setPhrase(code);
+          setLog((prev) =>
+            appendLogLine(prev, `Code is: ${code}`),
+          );
+        }
+      });
+      unlistenPhase = await listen<PhaseV2Event>("transfer-phase", (event) => {
+        const { phase, message } = event.payload;
+        if (!phase) return;
+        // Mirror the phase into the log for visibility.
+        if (message) {
+          setLog((prev) => appendLogLine(prev, message));
+        }
+        // Map croc's "complete" phase to the GUI's "completed" terminal
+        // state immediately. The transfer-exit event will also fire, but
+        // this gives a faster UI update (no waiting for the process to
+        // actually exit).
+        if (phase === "complete") {
+          lastProgressAt.current = null;
+          if (phaseRef.current === "running") {
+            setPhase("completed");
+            setProgress((prev) => ({
+              ...prev,
+              percent: 100,
+              phase: "finishing",
+            }));
+            recordHistory("completed");
+            notify(
+              "Croc — transfer complete",
+              "Your transfer finished successfully.",
+            );
+          }
+        }
+      });
+      unlistenProgressV2 = await listen<ProgressV2Event>(
+        "transfer-progress-v2",
+        (event) => {
+          const p = event.payload;
+          lastProgressAt.current = Date.now();
+          const percent = Number.isFinite(p.percent)
+            ? Math.max(0, Math.min(100, Math.round(p.percent)))
+            : null;
+          // Convert bytes/s to a human-friendly "X MB/s" string so the
+          // existing speed UI keeps working.
+          const speed = formatSpeed(p.speedBps);
+          setProgress((prev) => ({
+            percent: percent ?? prev.percent,
+            bytesDone: p.bytesDone ?? prev.bytesDone,
+            bytesTotal: p.bytesTotal ?? prev.bytesTotal,
+            speed: speed ?? prev.speed,
+            phase: p.file ? "transferring" : prev.phase,
+            label: p.file ?? prev.label,
+          }));
+        },
+      );
+      unlistenComplete = await listen<CompleteV2Event>(
+        "transfer-complete",
+        (event) => {
+          // Already handled in transfer-phase "complete", but we use this
+          // hook to log the file list for diagnostic visibility.
+          const names = (event.payload.files ?? [])
+            .map((f) => f.name)
+            .join(", ");
+          if (names) {
+            setLog((prev) => appendLogLine(prev, `Transferred: ${names}`));
+          }
+        },
+      );
+      unlistenError = await listen<ErrorV2Event>(
+        "transfer-error",
+        (event) => {
+          // croc emits stable error codes (auth_failed, handshake_failed,
+          // timed_out, relay_unreachable, etc.) with a hint field. Show
+          // the hint in the error banner if present; fall back to the
+          // raw message. This replaces the regex `relayHandshakeErrorMessage`
+          // for v11+ croc binaries.
+          if (phaseRef.current !== "running") return;
+          const { code, message, hint } = event.payload;
+          const text = hint && code !== "failed" ? hint : message;
+          setError(`Transfer error (${code}): ${text}`);
+        },
+      );
       unlistenLine = await listen<LineEvent>("transfer-line", (event) => {
         const { line, code } = event.payload;
         setLog((prev) => appendLogLine(prev, line));
@@ -711,6 +831,11 @@ function App() {
       unlistenLine?.();
       unlistenProgress?.();
       unlistenExit?.();
+      unlistenCode?.();
+      unlistenPhase?.();
+      unlistenProgressV2?.();
+      unlistenComplete?.();
+      unlistenError?.();
     };
   }, []);
 

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -102,21 +102,25 @@ type ProgressV2Event = {
   bytesTotal: number;
   speedBps: number;
   file: string | null;
+  sessionId: number;
 };
 
 type PhaseV2Event = {
   phase: string;
   message: string | null;
+  sessionId: number;
 };
 
 type CompleteV2Event = {
   files: Array<{ name: string; bytes: number }>;
+  sessionId: number;
 };
 
 type ErrorV2Event = {
   code: string;
   message: string;
   hint: string | null;
+  sessionId: number;
 };
 
 type ProgressState = {
@@ -659,8 +663,12 @@ function App() {
         }
       });
       unlistenPhase = await listen<PhaseV2Event>("transfer-phase", (event) => {
-        const { phase, message } = event.payload;
+        const { phase, message, sessionId } = event.payload;
         if (!phase) return;
+        // Ignore events from previous sessions.
+        if (sessionId != null && sessionId !== transferSessionRef.current) {
+          return;
+        }
         // Mirror the phase into the log for visibility.
         if (message) {
           setLog((prev) => appendLogLine(prev, message));
@@ -690,6 +698,10 @@ function App() {
         "transfer-progress-v2",
         (event) => {
           const p = event.payload;
+          // Ignore events from previous sessions.
+          if (p.sessionId != null && p.sessionId !== transferSessionRef.current) {
+            return;
+          }
           lastProgressAt.current = Date.now();
           const percent = Number.isFinite(p.percent)
             ? Math.max(0, Math.min(100, Math.round(p.percent)))
@@ -710,6 +722,13 @@ function App() {
       unlistenComplete = await listen<CompleteV2Event>(
         "transfer-complete",
         (event) => {
+          // Ignore events from previous sessions.
+          if (
+            event.payload.sessionId != null &&
+            event.payload.sessionId !== transferSessionRef.current
+          ) {
+            return;
+          }
           // Already handled in transfer-phase "complete", but we use this
           // hook to log the file list for diagnostic visibility.
           const names = (event.payload.files ?? [])
@@ -723,6 +742,13 @@ function App() {
       unlistenError = await listen<ErrorV2Event>(
         "transfer-error",
         (event) => {
+          // Ignore events from previous sessions.
+          if (
+            event.payload.sessionId != null &&
+            event.payload.sessionId !== transferSessionRef.current
+          ) {
+            return;
+          }
           // croc emits stable error codes (auth_failed, handshake_failed,
           // timed_out, relay_unreachable, etc.) with a hint field. Show
           // the hint in the error banner if present; fall back to the

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -111,6 +111,11 @@ type PhaseV2Event = {
   sessionId: number;
 };
 
+type CodeV2Event = {
+  code: string;
+  sessionId: number;
+};
+
 type CompleteV2Event = {
   files: Array<{ name: string; bytes: number }>;
   sessionId: number;
@@ -650,16 +655,20 @@ function App() {
     let unlistenError: (() => void) | undefined;
 
     (async () => {
-      unlistenCode = await listen<string>("transfer-code", (event) => {
-        // The structured code event from croc --json. Authoritative — the
-        // legacy `transfer-line` "Code is:" regex is broken on v11+, so
-        // this is the only reliable source.
-        const code = event.payload;
+      unlistenCode = await listen<CodeV2Event>("transfer-code", (event) => {
+        // Drop events from previous/cancelled sessions — the pump
+        // thread can keep emitting after cancel until the pipe closes
+        // (Macroscope PR#8 review).
+        const { code, sessionId } = event.payload;
+        if (
+          sessionId != null &&
+          sessionId !== transferSessionRef.current
+        ) {
+          return;
+        }
         if (code && typeof code === "string") {
           setPhrase(code);
-          setLog((prev) =>
-            appendLogLine(prev, `Code is: ${code}`),
-          );
+          setLog((prev) => appendLogLine(prev, `Code is: ${code}`));
         }
       });
       unlistenPhase = await listen<PhaseV2Event>("transfer-phase", (event) => {
@@ -673,24 +682,21 @@ function App() {
         if (message) {
           setLog((prev) => appendLogLine(prev, message));
         }
-        // Map croc's "complete" phase to the GUI's "completed" terminal
-        // state immediately. The transfer-exit event will also fire, but
-        // this gives a faster UI update (no waiting for the process to
-        // actually exit).
+        // When croc reports "complete", the file transfer is done but
+        // post-processing (e.g. zipAfterReceive) may still be running.
+        // Flip the progress bar to "finishing" here for instant feedback,
+        // but do NOT mark the transfer "completed" yet — that requires
+        // the process to actually exit successfully (`transfer-exit`
+        // handles it), otherwise post-processing failures are hidden
+        // (Macroscope PR#8 review).
         if (phase === "complete") {
           lastProgressAt.current = null;
           if (phaseRef.current === "running") {
-            setPhase("completed");
             setProgress((prev) => ({
               ...prev,
               percent: 100,
               phase: "finishing",
             }));
-            recordHistory("completed");
-            notify(
-              "Croc — transfer complete",
-              "Your transfer finished successfully.",
-            );
           }
         }
       });

--- a/gui/src/speedFormat.test.ts
+++ b/gui/src/speedFormat.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { formatSpeed } from "./speedFormat";
+
+describe("formatSpeed", () => {
+  it("returns null for zero", () => {
+    expect(formatSpeed(0)).toBeNull();
+  });
+
+  it("returns null for negative values", () => {
+    expect(formatSpeed(-100)).toBeNull();
+  });
+
+  it("returns null for non-finite values", () => {
+    expect(formatSpeed(Number.NaN)).toBeNull();
+    expect(formatSpeed(Number.POSITIVE_INFINITY)).toBeNull();
+  });
+
+  it("formats B/s for small values", () => {
+    expect(formatSpeed(500)).toBe("500 B/s");
+  });
+
+  it("formats kB/s for thousands", () => {
+    expect(formatSpeed(2_500)).toBe("2.5 kB/s");
+    expect(formatSpeed(99_999)).toBe("100 kB/s");
+  });
+
+  it("formats MB/s for millions", () => {
+    expect(formatSpeed(5_242_880)).toBe("5.2 MB/s");
+    expect(formatSpeed(256_333_767)).toBe("256 MB/s");
+  });
+
+  it("formats GB/s for billions", () => {
+    expect(formatSpeed(2_500_000_000)).toBe("3 GB/s");
+  });
+});

--- a/gui/src/speedFormat.ts
+++ b/gui/src/speedFormat.ts
@@ -1,0 +1,32 @@
+//! Format raw `bytesPerSecond` from croc's `--json` progress events into a
+//! human-friendly string like "5.2 MB/s" for the transfer UI.
+//!
+//! Extracted from `App.tsx` so the formatting can be unit-tested without
+//! pulling in the React tree.
+
+export type FormattedSpeed = string | null;
+
+/** Convert raw bytes-per-second into a human-friendly speed string.
+ *  Returns `null` for zero/negative/non-finite inputs so the UI keeps the
+ *  previous value. */
+export function formatSpeed(bytesPerSecond: number): FormattedSpeed {
+  if (!Number.isFinite(bytesPerSecond) || bytesPerSecond <= 0) {
+    return null;
+  }
+  const units = ["B/s", "kB/s", "MB/s", "GB/s"];
+  let value = bytesPerSecond;
+  let unitIndex = 0;
+  while (value >= 1000 && unitIndex < units.length - 1) {
+    value /= 1000;
+    unitIndex += 1;
+  }
+  // Croc uses MB/s for most transfers; show one decimal for sub-100
+  // values, integers for everything else. Rounding first means 99.999
+  // collapses to "100" rather than "100.0".
+  const rounded = Math.round(value);
+  const formatted =
+    unitIndex === 0 || unitIndex === units.length - 1 || rounded >= 100
+      ? rounded.toString()
+      : value.toFixed(1);
+  return `${formatted} ${units[unitIndex]}`;
+}


### PR DESCRIPTION
Adopt croc --json events (schollz/croc#1237)

Migrates the Tauri backend to consume croc's machine-readable NDJSON
event stream (added in croc v11.1.0 via [schollz/croc#1237][pr]). The
legacy regex-based progress parser stays as a fallback so v10 binaries
keep working.

[pr]: https://github.com/schollz/croc/pull/1237

## What's new

New Tauri events emitted to the frontend (in parallel with the legacy
`transfer-line` / `transfer-progress`):

| Event              | Replaces / fixes                                       |
| ------------------ | ------------------------------------------------------ |
| `transfer-code`    | Broken `Code is: <code>` regex on croc v11+            |
| `transfer-phase`   | Inferred phase from human progress bars                |
| `transfer-progress-v2` | `int64` bytes + speed; no more `parse_human_bytes` |
| `transfer-complete`| Inferred from 99%/100% heuristic                       |
| `transfer-error`   | Raw cipher error text; now shows croc's hint strings   |

## Why

The current code parses croc's *human* output (`Sending 'X' 50% |██ | (10 MB/50 MB, 5 MB/s)`)
with regex. That breaks every time croc changes its output format — it
already broke once on v11 when `Code is:` stopped being printed. The new
upstream `--json` flag gives us a stable contract.

## Implementation

**Backend (`gui/src-tauri/`):**
- `events.rs` (new): `CrocEvent` enum, `EventSink` trait, async + sync
  NDJSON pump. Falls back to forwarding unparseable lines to the legacy
  log path so nothing is lost on older croc versions.
- `croc.rs`: `use_json_events: bool` field on `TransferOptions`
  (default `true`); `croc_supports_json()` cache probes `croc --json
  send --help` once to detect v10 vs v11+; `build_args` only adds
  `--json` when the probe returns true.
- `lib.rs`: `TauriEventSink` impl routes parsed events to Tauri emits;
  `start_transfer` pumps stderr through the JSON consumer alongside the
  legacy log pump.

**Frontend (`gui/src/`):**
- `App.tsx`: 5 new `listen<…>()` handlers for the v2 events. The
  `transfer-phase:complete` event flips the UI to "completed"
  immediately, the `transfer-error` event shows croc's official
  `auth_failed` / `handshake_failed` / `timed_out` hints instead of
  the raw cipher error, and the v2 `transfer-code` listener replaces
  the broken regex.
- `speedFormat.ts` (new): `bytesPerSecond` → `"5.2 MB/s"` formatter.

## Build artifact note

The bundled croc in `src-tauri/bin/` must be **v11.1.0 or later** for
`--json` to work. The repo's current `bin/croc` is **v11.0.0** (too
old) and `npm run bundle:croc:download` currently pulls v11.1.1 which
is also pre-`--json` (the PR was merged *after* v11.1.1 was tagged).

The first release DMG in this PR was built with a v11.1.0 binary
**built from the `main` branch of schollz/croc** (which includes
#1237) — see the `docs/` notes for a one-line `go build` recipe. Once
croc ships v11.2.0+ with the flag, `npm run bundle:croc:download` will
just work.

## Tested locally

- **46 Rust tests** pass (`cargo test --manifest-path src-tauri/Cargo.toml --lib`)
- **58 TypeScript tests** pass (`npm test`)
- **Live e2e on Apple Silicon + Intel** with public relay:
  - Sender stream: `version`, `code`, `phase:hashing`, `phase:connecting`,
    `phase:transferring`, `progress` (×N), `complete`, `phase:complete`
  - Receiver stream: same minus `code`
  - 0 invalid JSON lines across all runs
  - Error path: `auth_failed` / `handshake_failed` codes fire with
    proper hint strings
- **DMGs built and verified** for both architectures (arm64 + x86_64);
  both ship a v11.1.0+ croc that supports `--json`

## Reviewer notes

- No new dependencies. `serde_json` was already in `Cargo.toml`.
- ~400 lines of fragile regex parsing in `progress.rs` and
  `extract_code_phrase` in `croc.rs` are kept for the v10 fallback;
  they can be deleted in a follow-up once we drop v10 support.
- The legacy `transfer-line` and `transfer-progress` events still
  fire in parallel; nothing in the current UI relies on them being
  removed.

## Related

- Upstream PR: https://github.com/schollz/croc/pull/1237
- Companion review comment: see my notes on that PR


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add croc `--json` event pipeline for structured transfer progress in the UI
> - Probes the croc binary for `--json` support (croc v11+) before passing the flag, caching the result per binary path in [`croc.rs`](https://github.com/interfluve-wav/croc-gui/pull/8/files#diff-e4564d1134928bb7de88561b40f95c45e26d60e7ff72d757c96cf0dea4525605) to avoid repeated probes.
> - Adds a new [`events.rs`](https://github.com/interfluve-wav/croc-gui/pull/8/files#diff-b39dd4a831483f869f07d265debdaaedd08370fbd87b1b0cea1ca2682719ff4f) module that reads croc's NDJSON stderr stream and dispatches typed events (progress, phase, code, complete, error) via a `TauriEventSink` adapter.
> - Updates [`App.tsx`](https://github.com/interfluve-wav/croc-gui/pull/8/files#diff-5cf4d71f8d3aeb224d9f9bf7fc1437bedb87b6c5ae3876999c1619044c022d75) to listen for the new structured events and update UI state (phase, speed via `formatSpeed`, file names, errors), scoped by `sessionId` to discard stale events.
> - Extracts speed formatting into a shared [`speedFormat.ts`](https://github.com/interfluve-wav/croc-gui/pull/8/files#diff-1106265539e14edab5aba4396128d0db819f9b76df5c77d2d0f8499c5dbbf329) utility.
> - Behavioral Change: stderr lines that parse as JSON are no longer emitted as `transfer-line`; only non-JSON stderr lines continue on that channel.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 637b65e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer transfer progress updates, including transfer phases, completion status, errors, and live speed formatting.
  * Improved transfer logs with structured event details and readable fallback messages.
* **Bug Fixes**
  * Improved compatibility across supported croc versions by automatically detecting JSON event support.
  * Retained legacy output handling when structured events are unavailable.
* **Tests**
  * Added coverage for transfer event processing and speed formatting across common units and invalid values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->